### PR TITLE
Modal inline example

### DIFF
--- a/packages/modals/src/elements/Modal.example.md
+++ b/packages/modals/src/elements/Modal.example.md
@@ -210,3 +210,47 @@ const onModalClose = () => setState({ isModalVisible: false });
   )}
 </div>;
 ```
+
+### Positioning
+
+```jsx
+const { zdSpacing } = require('@zendeskgarden/css-variables');
+const { Button } = require('@zendeskgarden/react-buttons/src');
+
+initialState = {
+  isModalVisible: false,
+  isInline: false
+};
+
+const onModalClose = () => setState({ isModalVisible: false });
+
+<div style={{ position: 'relative', height: 500 }}>
+  <Grid>
+    <Row>
+      <Col md>
+        <Button onClick={() => setState({ isModalVisible: true, isInline: false })}>
+          Standard
+        </Button>
+      </Col>
+      <Col md>
+        <Button onClick={() => setState({ isModalVisible: true, isInline: true })}>Inline</Button>
+      </Col>
+    </Row>
+  </Grid>
+  {state.isModalVisible && (
+    <Modal onClose={onModalClose} style={{ paddingBottom: zdSpacing }} isInline={state.isInline}>
+      <Header>{state.width} Header</Header>
+      <Body>
+        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has
+        been the industry's standard dummy text ever since the 1500s, when an unknown printer took a
+        galley of type and scrambled it to make a type specimen book. It has survived not only five
+        centuries, but also the leap into electronic typesetting, remaining essentially unchanged.
+        It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum
+        passages, and more recently with desktop publishing software like Aldus PageMaker including
+        versions of Lorem Ipsum.
+      </Body>
+      <Close aria-label="Close modal" />
+    </Modal>
+  )}
+</div>;
+```

--- a/packages/modals/src/elements/Modal.js
+++ b/packages/modals/src/elements/Modal.js
@@ -46,7 +46,20 @@ const isOverflowing = element => {
  * High-level abstraction for basic Modal implementations. Accepts all `<div>` props.
  */
 const Modal = React.forwardRef(
-  ({ backdropProps, children, onClose, center, animate, id, appendToNode, ...modalProps }, ref) => {
+  (
+    {
+      backdropProps,
+      children,
+      onClose,
+      center,
+      animate,
+      id,
+      appendToNode,
+      isInline,
+      ...modalProps
+    },
+    ref
+  ) => {
     const modalRef = useCombinedRefs(ref);
 
     const {
@@ -79,9 +92,11 @@ const Modal = React.forwardRef(
       };
     }, []);
 
-    return createPortal(
-      <Backdrop {...getBackdropProps({ center, animate, ...backdropProps })}>
-        <ModalView {...getModalProps({ animate, ref: modalRef, ...modalProps })}>
+    const renderModal = element => (isInline ? element : createPortal(element, appendToNode));
+
+    return renderModal(
+      <Backdrop {...getBackdropProps({ center, animate, isInline, ...backdropProps })}>
+        <ModalView {...getModalProps({ animate, isInline, ref: modalRef, ...modalProps })}>
           {Children.map(children, child => {
             if (!isValidElement(child)) {
               return child;
@@ -139,7 +154,11 @@ Modal.propTypes = {
   /**
    * The root ID to use for descendants. A unique ID is created if none is provided.
    **/
-  id: PropTypes.string
+  id: PropTypes.string,
+  /**
+   * Render the modal where the component is rendered
+   */
+  isInline: PropTypes.bool
 };
 
 Modal.defaultProps = {

--- a/packages/modals/src/views/Backdrop.js
+++ b/packages/modals/src/views/Backdrop.js
@@ -28,6 +28,10 @@ const Backdrop = styled.div.attrs(props => ({
   })
 }))`
   ${props => retrieveTheme(COMPONENT_ID, props)};
+
+  &&& {
+    ${props => props.isInline && `position: absolute;`}
+  }
 `;
 
 Backdrop.propTypes = {

--- a/packages/modals/src/views/ModalView.js
+++ b/packages/modals/src/views/ModalView.js
@@ -31,6 +31,13 @@ const ModalView = styled.div.attrs(props => ({
   })
 }))`
   ${props => retrieveTheme(COMPONENT_ID, props)};
+  ${props =>
+    props.isInline &&
+    `
+    &&& {
+    position: absolute;
+    }
+  `}
 `;
 
 ModalView.propTypes = {


### PR DESCRIPTION
## Description

Example of prop `isInline` for Modal

**What hasn't been addressed**
- It seems while the inline modal is open, you can't click anywhere outside of the modal/backdrop.
- When the `position: relative;` container is smaller than the modal, it doesn't scroll resulting in part of the modal being cut off
- `position: absolute;` was added via `styled-components` which isn't the right approach for v7. Would the css files need to be updated?

![modal inline example](https://user-images.githubusercontent.com/4470300/75948891-c51af500-5ef8-11ea-86d2-e4132cf7874a.gif)


## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
